### PR TITLE
Support for StringIO and Tempfile

### DIFF
--- a/lib/free-image/bitmap.rb
+++ b/lib/free-image/bitmap.rb
@@ -166,7 +166,7 @@ module FreeImage
       case source
       when AbstractSource
         source
-      when ::IO
+      when ::IO, (const_get(:StringIO) rescue ::IO), (const_get(:Tempfile) rescue ::IO)
         IO.new(source)
       when String
         File.new(source)

--- a/lib/free-image/bitmap.rb
+++ b/lib/free-image/bitmap.rb
@@ -166,7 +166,7 @@ module FreeImage
       case source
       when AbstractSource
         source
-      when ::IO, (const_get(:StringIO) rescue ::IO), (const_get(:Tempfile) rescue ::IO)
+      when ::IO, (StringIO if defined? StringIO), (Tempfile if defined? Tempfile)
         IO.new(source)
       when String
         File.new(source)


### PR DESCRIPTION
This adds support for StringIO and Tempfile from the standard library. It is dynamic so StringIO and Tempfile don't need to be `require`'d by FreeImage.
